### PR TITLE
DIVU by 0 should produce max value

### DIFF
--- a/riscv/insts/integer/extensions/multiply/r/divu.kt
+++ b/riscv/insts/integer/extensions/multiply/r/divu.kt
@@ -13,26 +13,26 @@ val divu = RTypeInstruction(
         eval16 = { a, b ->
             val x = a.toInt() shl 16 ushr 16
             val y = b.toInt() shl 16 ushr 16
-            if (y == (0L).toInt()) Short.MAX_VALUE
+            if (y == (0L).toInt()) (-1).toShort()
             else (x / y).toShort()
         },
         eval32 = { a, b ->
             val x = a.toLong() shl 32 ushr 32
             val y = b.toLong() shl 32 ushr 32
-            if (y == 0L) Int.MAX_VALUE
+            if (y == 0L) (-1).toInt() 
             else (x / y).toInt()
         },
         eval64 = { a, b ->
             val x = a.toQuadWord() shl 64 ushr 64
             val y = b.toQuadWord() shl 64 ushr 64
-            if (y == QuadWord()) Long.MAX_VALUE
+            if (y == QuadWord()) (-1).toLong()
             else (x / y).toLong()
         },
         /*FIXME 128 need to be able to convert to larger things that LONG*/
         eval128 = { a, b ->
             val x = a.toDoubleQuadWord() shl 128 ushr 128
             val y = b.toDoubleQuadWord() shl 128 ushr 128
-            if (y == 0.toDoubleQuadWord()) QuadWord.MAX_VALUE
+            if (y == 0.toDoubleQuadWord()) (-1).toQuadWord()
             else (x / y).toQuadWord()
         }
 )

--- a/riscv/insts/integer/extensions/multiply/r/divu.kt
+++ b/riscv/insts/integer/extensions/multiply/r/divu.kt
@@ -13,26 +13,26 @@ val divu = RTypeInstruction(
         eval16 = { a, b ->
             val x = a.toInt() shl 16 ushr 16
             val y = b.toInt() shl 16 ushr 16
-            if (y == (0L).toInt()) a
+            if (y == (0L).toInt()) Short.MAX_VALUE
             else (x / y).toShort()
         },
         eval32 = { a, b ->
             val x = a.toLong() shl 32 ushr 32
             val y = b.toLong() shl 32 ushr 32
-            if (y == 0L) a
+            if (y == 0L) Int.MAX_VALUE
             else (x / y).toInt()
         },
         eval64 = { a, b ->
             val x = a.toQuadWord() shl 64 ushr 64
             val y = b.toQuadWord() shl 64 ushr 64
-            if (y == QuadWord()) a
+            if (y == QuadWord()) Long.MAX_VALUE
             else (x / y).toLong()
         },
         /*FIXME 128 need to be able to convert to larger things that LONG*/
         eval128 = { a, b ->
             val x = a.toDoubleQuadWord() shl 128 ushr 128
             val y = b.toDoubleQuadWord() shl 128 ushr 128
-            if (y == 0.toDoubleQuadWord()) a
+            if (y == 0.toDoubleQuadWord()) QuadWord.MAX_VALUE
             else (x / y).toQuadWord()
         }
 )


### PR DESCRIPTION
DIVU by 0 currently returns the dividend, whereas the current spec for the M extension specifies that all bits should be set in the result.

I'm not sure if I made the change correctly, or if this was actually intended, I just thought I would let you know that I ran into this while using your fork of Venus. 