### PR TITLE
Fix sign bug in vaddh instruction

### DIFF
--- a/proj3_2-venus_package.js
+++ b/proj3_2-venus_package.js
@@ -15,7 +15,7 @@ var venuspackage = {
             var rs2 = numberToInt(sim.getReg_za3lpa$(mcode.get_cv51c2$(InstructionField$RS2_getInstance())));
             var upper = toShort(rs1 >> 16) + toShort(rs2 >> 16);
             var lower = toShort(toShort(rs1) + toShort(rs2));
-            var rd = upper << 16 | lower;
+            var rd = upper << 16 | (lower & 0xFFFF);
             sim.setReg_135bro$(mcode.get_cv51c2$(InstructionField$RD_getInstance()), rd);
             sim.incrementPC_3p81yu$(mcode.length);
             return Unit;

--- a/riscv/insts/integer/extensions/proj3/vaddh.kt
+++ b/riscv/insts/integer/extensions/proj3/vaddh.kt
@@ -18,7 +18,7 @@ val vaddh = Instruction(
             val rs2 = sim.getReg(mcode[InstructionField.RS2]).toInt()
             val upper = (rs1 shr 16).toShort() + (rs2 shr 16).toShort()
             val lower = (rs1.toShort() + rs2.toShort()).toShort().toInt()
-            val rd = (upper shl 16) or lower
+            val rd = (upper shl 16) or (lower and 0xFFFF)
             sim.setReg(mcode[InstructionField.RD], rd)
             sim.incrementPC(mcode.length)
         },


### PR DESCRIPTION
Previously `0xFFFFFF24 vaddh 0xFFFFFF89` resulted in an output of `0xFFFFFEAD` (should have been `0xFFFEFEAD`). Essentially, if the lower part was negative, then it would add one to the upper part.

I checked the following code in an online kotlin interpreter and it solved the issue. I don't think javascript had the issue previously, but I added the same code idiom anyways for consistency.