### PR TITLE
Add ecall hooks

### DIFF
--- a/riscv/insts/integer/base/i/ecall/ecall.kt
+++ b/riscv/insts/integer/base/i/ecall/ecall.kt
@@ -17,6 +17,9 @@ import venusbackend.riscv.insts.dsl.parsers.DoNothingParser
 import venusbackend.riscv.MemorySegments
 import venusbackend.simulator.FilesHandler
 import venusbackend.simulator.Simulator
+import kotlin.js.JSON
+import kotlin.js.Json
+import kotlin.js.json
 
 val ecall = Instruction(
     // Fixme The long and quadword are only build for a 32 bit system!
@@ -45,7 +48,7 @@ val ecall = Instruction(
                 20 -> ferror(sim)
                 34 -> printHex(sim)
                 0x3CC -> clib(sim)
-                else -> Renderer.printConsole("Invalid ecall $whichCall")
+                else -> invokeECall(whichCall.toInt(), sim)
             }
             if (!(whichCall == 10 || whichCall == 17)) {
                 sim.incrementPC(mcode.length)
@@ -69,7 +72,7 @@ val ecall = Instruction(
                 19L -> feof(sim)
                 20L -> ferror(sim)
                 34L -> printHex(sim)
-                else -> Renderer.printConsole("Invalid ecall $whichCall")
+                else -> invokeECall(whichCall.toInt(), sim)
             }
             if (!(whichCall == 10L || whichCall == 17L)) {
                 sim.incrementPC(mcode.length)
@@ -93,7 +96,7 @@ val ecall = Instruction(
                 QuadWord(19) -> feof(sim)
                 QuadWord(20) -> ferror(sim)
                 QuadWord(34) -> printHex(sim)
-                else -> Renderer.printConsole("Invalid ecall $whichCall")
+                else -> invokeECall(whichCall.toInt(), sim)
             }
             if (!(whichCall == QuadWord(10) || whichCall == QuadWord(17))) {
                 sim.incrementPC(mcode.length)
@@ -119,6 +122,11 @@ enum class Syscall(val syscall: Int) {
     FERROR(20),
     PRINT_HEX(34)
 }
+
+private fun invokeECall(id: Int, sim: Simulator) {
+    if (!sim.invokeECallReceiver(id)) Renderer.printConsole("Invalid ecall $id")
+}
+
 
 // All file operations will return -1 if the file descriptor is not found.
 private fun openFile(sim: Simulator) {

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -43,6 +43,7 @@ open class Simulator(
     val alloc: Alloc = Alloc(this)
 
     val plugins = LinkedHashMap<String, SimulatorPlugin>()
+    val ECallReceiver = ArrayList<(Int) -> Boolean>()
 
     init {
         (state).getReg(1)
@@ -103,6 +104,17 @@ open class Simulator(
 
     fun finishPlugins() {
         plugins.values.forEach { it.finish(this) }
+    }
+
+    fun registerECallReceiver(receiver: (Int) -> Boolean) {
+        ECallReceiver.add(receiver)
+    }
+
+    fun invokeECallReceiver(id: Int): Boolean {
+        ECallReceiver.forEach {
+            e -> e.invoke(id)
+        }
+        return true
     }
 
     fun setHistoryLimit(limit: Int) {


### PR DESCRIPTION
Adds capability to register an ecall receiver. A frontend can thereby implement its own ecalls for example to visualize data. When there is no standard ecall defined an ecall receiver is called.

The ecall hook is registered with `registerEcallReceiver`. The prototype of the registered hook function is `(String) -> (String)` where the String is json. This json contains the id and the other argument registers as `a0` to `a7`.

If the hook returns `a0` and `a1` in the returned json, the registers are updated accordingly.