### PR TITLE
Fix B-type immediate range

### DIFF
--- a/riscv/insts/dsl/parsers/DoNothingParser.kt
+++ b/riscv/insts/dsl/parsers/DoNothingParser.kt
@@ -5,8 +5,8 @@ import venusbackend.riscv.MachineCode
 import venusbackend.riscv.Program
 
 object DoNothingParser : InstructionParser {
-    const val B_TYPE_MIN = -2048
-    const val B_TYPE_MAX = 2047
+    const val B_TYPE_MIN = -4096
+    const val B_TYPE_MAX = 4095
     override operator fun invoke(prog: Program, mcode: MachineCode, args: List<String>, dbg: DebugInfo) {
         checkArgsLength(args.size, 0, dbg)
     }

--- a/riscv/insts/dsl/parsers/base/BTypeParser.kt
+++ b/riscv/insts/dsl/parsers/base/BTypeParser.kt
@@ -11,8 +11,8 @@ import venusbackend.riscv.insts.dsl.parsers.regNameToNumber
 /* ktlint-enable no-wildcard-imports */
 
 object BTypeParser : InstructionParser {
-    const val B_TYPE_MIN = -2048
-    const val B_TYPE_MAX = 2047
+    const val B_TYPE_MIN = -4096
+    const val B_TYPE_MAX = 4095
     override operator fun invoke(prog: Program, mcode: MachineCode, args: List<String>, dbg: DebugInfo) {
         checkArgsLength(args.size, 3, dbg)
 


### PR DESCRIPTION
Although the instruction encoding has 12 bits for the immediate, it represents `imm[12:1]` with an implicit `imm[0] = 0`. The valid range is thus `[-2^12, +2^12-1]` (in multiples of 2). From RISC-V Unprivileged ISA V20191213, page 22:

> The 12-bit B-immediate encodes signed offsets in multiples of 2 bytes.  The offset is sign-extended and added to the address of the branch instruction to give the target address.  The conditional branch range is ±4 KiB.

I might be missing something, but are the constants in DoNothingParser being used?